### PR TITLE
Use rexrex for regular expressions

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--registry "https://registry.yarnpkg.com"

--- a/lib/parseMarkdown.js
+++ b/lib/parseMarkdown.js
@@ -1,4 +1,31 @@
-const isCommandRe = /^\s*Run\s+tasks?\s+(.+)\s+(after|before)\s+this(\s+in\s+parallel)?\s*/i
+const {
+  wildcard,
+  capture,
+  extra,
+  or,
+  and,
+  matchers: { ANY, WHITE_SPACE: SPACE, START, LAZY },
+  flags
+} = require('rexrex')
+
+const space = extra(SPACE)
+const isCommentReTemplate = and(
+  START, // ^
+  wildcard(SPACE),
+  [
+    'Run',
+    'tasks' + LAZY,
+    capture(extra(ANY)),
+    capture(or('after', 'before')),
+    'this'
+  ].join(space),
+  capture(and(space, 'in', space, 'parallel')),
+  LAZY,
+  wildcard(SPACE)
+)
+
+const isCommandRe = new RegExp(isCommentReTemplate, flags.INSENSITIVE)
+
 const isCommand = v => isCommandRe.test(v)
 const parseCommand = v => {
   const [, command, when, inParallel] = isCommandRe.exec(v)

--- a/lib/parseMarkdown.js
+++ b/lib/parseMarkdown.js
@@ -9,7 +9,7 @@ const {
 } = require('rexrex')
 
 const space = extra(SPACE)
-const isCommentReTemplate = and(
+const isCommandReTemplate = and(
   START, // ^
   wildcard(SPACE),
   [
@@ -24,7 +24,7 @@ const isCommentReTemplate = and(
   wildcard(SPACE)
 )
 
-const isCommandRe = new RegExp(isCommentReTemplate, flags.INSENSITIVE)
+const isCommandRe = new RegExp(isCommandReTemplate, flags.INSENSITIVE)
 
 const isCommand = v => isCommandRe.test(v)
 const parseCommand = v => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "fancy-log": "^1.3.2",
     "markdown-it": "^8.4.1",
     "micromatch": "^3.1.10",
-    "require-from-string": "^2.0.2"
+    "require-from-string": "^2.0.2",
+    "rexrex": "^1.2.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,7 +3537,7 @@ ret@~0.1.10:
 
 rexrex@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.intuit.net/r/rexrex/_attachments/rexrex-1.2.0.tgz#bc5af894d555f0f45a6216d1c0ec3ecf6438667b"
+  resolved "https://registry.yarnpkg.com/rexrex/-/rexrex-1.2.0.tgz#bc5af894d555f0f45a6216d1c0ec3ecf6438667b"
 
 rimraf@^2.2.8, rimraf@^2.6.1:
   version "2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,6 +3535,10 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
+rexrex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.intuit.net/r/rexrex/_attachments/rexrex-1.2.0.tgz#bc5af894d555f0f45a6216d1c0ec3ecf6438667b"
+
 rimraf@^2.2.8, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"


### PR DESCRIPTION
`rexrex` just makes it easier to understand, debug, and digest regular expressions. In this case you can make comments on individual parts, and easier understand parts that can be reused (see `space`) or even removed.

I only converted on regular expression to use `rexrex` but i can do the others if you like this style. If you don't, please close (: 

This would also be beneficial for #13's regex if you go that route. 