### PR TITLE
Fix readme code block type

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Hook syntax:
 
 The CLI arguments are passed to executed script, so you can access it like this:
 
-````bash
+````markdown
 ## log
 
 ```bash


### PR DESCRIPTION
A code block had the kind bash instead of markdown, making the heading highlighting wrong:
```bash
## log
```
to 
```markdown
## log
```