### PR TITLE
Write maid scripts to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,14 +281,12 @@ It's recommended to use this technique along side [lint-staged](https://github.c
     }
   },
   "lint-staged": {
-    "README.md": ["maid update-scripts --git-add --noop", "git add"]
+    "README.md": ["maid update-scripts --git-add", "git add"]
   }
 }
 ```
 
 **Note:** The `--git-add` flag will automatically stage the `package.json`. If you have other changes to the package.json when that happens you could end up commiting those changes without intending to.
-
-The `--noop` flag ignores the next input. It's useful if you're using the default maidfile path configuration with lint-staged.
 
 `--no-write` allows you to test the command without actually updating the package.json. Useful for both debugging and checking to ensure there are no command conflicts
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
       - [Asynchronous task](#asynchronous-task)
     - [py/python](#pypython)
   - [Use a custom maidfile](#use-a-custom-maidfile)
+  - [Synchronizing tasks with package.json scripts](#synchronizing-tasks-with-packagejson-scripts)
 - [Development](#development)
   - [lint](#lint)
   - [test](#test)
@@ -261,6 +262,29 @@ Let me explain..
 Unlike a `maidfile.md` which uses all `h2` headers as tasks, in `README.md` only `h3` headers under the specified `h2` header will be used as tasks. You can add a `<!-- maid-tasks -->` comment right below the desired `h2` header.
 
 Alternatively, if you're not using `maidfile.md`, you can also use `--section h2_header` and `--path foo.md` flags to customize it.
+
+### Synchronizing tasks with package.json scripts
+
+You're team may currently use `yarn` or `npm run` to execute tasks. In order to reduce workflow churn maid provides a way of automatically updating the scripts section of your package.json with the relavent maid tasks.
+
+```bash
+maid update-scripts
+```
+
+It's recommended to use this technique along side [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky) to automatically update your package.json on before commiting changes to your maid tasks.
+
+```json
+{
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "README.md": ["maid update-scripts --git-add -p", "git add"]
+  }
+}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-
 # maid
 
-[![NPM version](https://img.shields.io/npm/v/maid.svg?style=flat)](https://npmjs.com/package/maid) [![NPM downloads](https://img.shields.io/npm/dm/maid.svg?style=flat)](https://npmjs.com/package/maid) [![CircleCI](https://circleci.com/gh/egoist/maid/tree/master.svg?style=shield)](https://circleci.com/gh/egoist/maid/tree/master)  [![donate](https://img.shields.io/badge/$-donate-ff69b4.svg?maxAge=2592000&style=flat)](https://github.com/egoist/donate) [![chat](https://img.shields.io/badge/chat-on%20discord-7289DA.svg?style=flat)](https://chat.egoist.moe)
+[![NPM version](https://img.shields.io/npm/v/maid.svg?style=flat)](https://npmjs.com/package/maid) [![NPM downloads](https://img.shields.io/npm/dm/maid.svg?style=flat)](https://npmjs.com/package/maid) [![CircleCI](https://circleci.com/gh/egoist/maid/tree/master.svg?style=shield)](https://circleci.com/gh/egoist/maid/tree/master) [![donate](https://img.shields.io/badge/$-donate-ff69b4.svg?maxAge=2592000&style=flat)](https://github.com/egoist/donate) [![chat](https://img.shields.io/badge/chat-on%20discord-7289DA.svg?style=flat)](https://chat.egoist.moe)
 
 > Markdown driven task runner.
 
@@ -9,7 +8,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Install](#install)
 - [What is a maidfile?](#what-is-a-maidfile)
@@ -52,13 +51,13 @@ npm i -D maid
 yarn add maid --dev
 ```
 
-<small>__PRO TIP__: you can use `npx` or `yarn` command to run any locally installed executable that is inside `node_modules/.bin/`, e.g. use `yarn maid` to run the locally installed maid command.</small>
+<small>**PRO TIP**: you can use `npx` or `yarn` command to run any locally installed executable that is inside `node_modules/.bin/`, e.g. use `yarn maid` to run the locally installed maid command.</small>
 
 ## What is a maidfile?
 
 A maidfile is where you define tasks, in Markdown!
 
-📝 __maidfile.md__:
+📝 **maidfile.md**:
 
 ````markdown
 ## lint
@@ -74,6 +73,7 @@ eslint --fix
 Build our main app
 
 <!-- Following line is a maid command for running task -->
+
 Run task `build:demo` after this
 
 ```bash
@@ -90,20 +90,21 @@ You can use JavaScript to write to task script too!
 const webpack = require('webpack')
 
 // Async task should return a Promise
-module.exports = () => new Promise((resolve, reject) => {
-  const compiler = webpack(require('./webpack.config'))
-  compiler.run((err, stats) => {
-    if (err) return reject(err)
-    console.log(stats.toString('minimal'))
-    resolve()
+module.exports = () =>
+  new Promise((resolve, reject) => {
+    const compiler = webpack(require('./webpack.config'))
+    compiler.run((err, stats) => {
+      if (err) return reject(err)
+      console.log(stats.toString('minimal'))
+      resolve()
+    })
   })
-})
 ```
 ````
 
-Each task is defined using `h2` header and its child contents, the value of `h2` header will be used as task name, its following paragraphs (optional) will be used as task description, and following code block (optional) will be used as task script. 
+Each task is defined using `h2` header and its child contents, the value of `h2` header will be used as task name, its following paragraphs (optional) will be used as task description, and following code block (optional) will be used as task script.
 
-Currently the code block languages are `sh` `bash` `js` `javascript` [and more](#code-block-languages)!. 
+Currently the code block languages are `sh` `bash` `js` `javascript` [and more](#code-block-languages)!.
 
 Now run `maid help` to display the help for this maidfile:
 
@@ -157,21 +158,21 @@ gh-pages -d dist
 ```
 ````
 
-Basically expressions like ``Run task `deploy` after this`` is treated specially, in this case if you run `maid build`, it will also run `deploy` task when `build` task is finished.
+Basically expressions like `` Run task `deploy` after this `` is treated specially, in this case if you run `maid build`, it will also run `deploy` task when `build` task is finished.
 
 The syntax is simple: `Run tasks? <taskNames> (before|after) this (in parallel)?` where each task name is surrounded by a pair of backticks: <code>`</code>.
 
 Examples:
 
-- ``Run task `build` after this.``
-- ``Run tasks `build:app` `start:server` before this.``
-- ``Run tasks `build:server` `build:client` before this in parallel.``
+- `` Run task `build` after this. ``
+- `` Run tasks `build:app` `start:server` before this. ``
+- `` Run tasks `build:server` `build:client` before this in parallel. ``
 
 ### Task hooks
 
 Like npm scripts, when you run a command called `build`, when it's finished we will also run `postbuild` task.
 
-Hook syntax: 
+Hook syntax:
 
 - `pre<taskName>`: Run before a specific task.
 - `post<taskName>`: Run after a specific task.
@@ -281,6 +282,8 @@ If you want to automatically fix lint errors, try adding `--fix` plugin to the c
 
 Use [AVA](https://github.com/avajs/ava) to run unit tests.
 
+Run task `lint` before this.
+
 ```bash
 yarn ava "${@:1}"
 ```
@@ -289,7 +292,7 @@ Similar to the `lint` task, you can append any flags for `ava` command directly 
 
 ### toc
 
-Generate a __table of contents__ section in the README.md file.
+Generate a **table of contents** section in the README.md file.
 
 ```bash
 yarn doctoc README.md
@@ -297,16 +300,15 @@ yarn doctoc README.md
 
 ## Contributing
 
-1. Fork it!
-2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -am 'Add some feature'`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request :D
-
+1.  Fork it!
+2.  Create your feature branch: `git checkout -b my-new-feature`
+3.  Commit your changes: `git commit -am 'Add some feature'`
+4.  Push to the branch: `git push origin my-new-feature`
+5.  Submit a pull request :D
 
 ## Author
 
 **maid** © [egoist](https://github.com/egoist), Released under the [MIT](./LICENSE) License.<br>
 Authored and maintained by egoist with help from contributors ([list](https://github.com/egoist/maid/contributors)).
 
-> [github.com/egoist](https://github.com/egoist) · GitHub [@egoist](https://github.com/egoist) · Twitter [@_egoistlily](https://twitter.com/_egoistlily)
+> [github.com/egoist](https://github.com/egoist) · GitHub [@egoist](https://github.com/egoist) · Twitter [@\_egoistlily](https://twitter.com/_egoistlily)

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ You're team may currently use `yarn` or `npm run` to execute tasks. In order to 
 maid update-scripts
 ```
 
-It's recommended to use this technique along side [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky) to automatically update your package.json on before commiting changes to your maid tasks.
+It's recommended to use this technique along side [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky) to automatically update your package.json in a precommit hook.
 
 ```json
 {
@@ -288,7 +288,9 @@ It's recommended to use this technique along side [lint-staged](https://github.c
 
 **Note:** The `--git-add` flag will automatically stage the `package.json`. If you have other changes to the package.json when that happens you could end up commiting those changes without intending to.
 
-The `--noop` flag ignores the next input. It's useful if you're using the default maidfile path configuration.
+The `--noop` flag ignores the next input. It's useful if you're using the default maidfile path configuration with lint-staged.
+
+`--no-write` allows you to test the command without actually updating the package.json. Useful for both debugging and checking to ensure there are no command conflicts
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -281,12 +281,14 @@ It's recommended to use this technique along side [lint-staged](https://github.c
     }
   },
   "lint-staged": {
-    "README.md": ["maid update-scripts --git-add -p", "git add"]
+    "README.md": ["maid update-scripts --git-add --noop", "git add"]
   }
 }
 ```
 
 **Note:** The `--git-add` flag will automatically stage the `package.json`. If you have other changes to the package.json when that happens you could end up commiting those changes without intending to.
+
+The `--noop` flag ignores the next input. It's useful if you're using the default maidfile path configuration.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ It's recommended to use this technique along side [lint-staged](https://github.c
 }
 ```
 
+**Note:** The `--git-add` flag will automatically stage the `package.json`. If you have other changes to the package.json when that happens you could end up commiting those changes without intending to.
+
 ## Development
 
 <!-- maid-tasks -->

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -44,4 +44,10 @@ cli.option('section', {
   alias: 's'
 })
 
+cli.option('update-scripts', {
+  desc: 'Write maid tasks to package.json scripts',
+  type: 'boolean',
+  default: false
+})
+
 cli.parse()

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,18 +1,8 @@
 #!/usr/bin/env node
 const cli = require('cac')()
 const chalk = require('chalk')
-const MaidError = require('../lib/MaidError')
 
 cli.command('*', 'Run a task in current working directory', (input, flags) => {
-  if (flags.updateScripts && input[0]) {
-    throw new MaidError('Cannot run task and update scripts')
-  } else if (flags.updateScripts) {
-    const runner = require('..')(flags)
-    const updateScripts = require('../lib/updateScripts')
-    updateScripts(runner)
-    return
-  }
-
   const taskName = input[0]
   if (!taskName) {
     return cli.showHelp()
@@ -20,6 +10,22 @@ cli.command('*', 'Run a task in current working directory', (input, flags) => {
   const runner = require('..')(flags)
   return runner.runFile(taskName)
 })
+
+cli
+  .command(
+    'update-scripts',
+    'Write maid tasks to package.json scripts',
+    (input, flags) => {
+      const runner = require('..')(flags)
+      const updateScripts = require('../lib/updateScripts')
+      updateScripts(runner, flags)
+    }
+  )
+  .option('git-add', {
+    desc: 'Runs git-add on the changed package.json file',
+    type: 'boolean',
+    default: false
+  })
 
 cli.command('help', 'Display task description', (input, flags) => {
   const runner = require('..')(flags)
@@ -52,11 +58,6 @@ cli.option('section', {
   desc: 'Which `h2` section to look under',
   type: 'string',
   alias: 's'
-})
-
-cli.option('update-scripts', {
-  desc: 'Write maid tasks to package.json scripts',
-  type: 'boolean'
 })
 
 cli.parse()

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
 const cli = require('cac')()
 const chalk = require('chalk')
+const MaidError = require('../lib/MaidError')
 
 cli.command('*', 'Run a task in current working directory', (input, flags) => {
+  if (flags.updateScripts && input[0]) {
+    throw new MaidError('Cannot run task and update scripts')
+  } else if (flags.updateScripts) {
+    const runner = require('..')(flags)
+    const updateScripts = require('../lib/updateScripts')
+    updateScripts(runner)
+    return
+  }
+
   const taskName = input[0]
   if (!taskName) {
     return cli.showHelp()
@@ -46,8 +56,7 @@ cli.option('section', {
 
 cli.option('update-scripts', {
   desc: 'Write maid tasks to package.json scripts',
-  type: 'boolean',
-  default: false
+  type: 'boolean'
 })
 
 cli.parse()

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,10 +26,6 @@ cli
     type: 'boolean',
     default: false
   })
-  .option('noop', {
-    type: 'string',
-    desc: 'Ignore the next option (useful for lint-staged)'
-  })
   .option('write', {
     type: 'boolean',
     default: true,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,6 +30,11 @@ cli
     type: 'string',
     desc: 'Ignore the next option (useful for lint-staged)'
   })
+  .option('write', {
+    type: 'boolean',
+    default: true,
+    desc: 'Write output to the package.json'
+  })
 
 cli.command('help', 'Display task description', (input, flags) => {
   const runner = require('..')(flags)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,6 +26,10 @@ cli
     type: 'boolean',
     default: false
   })
+  .option('noop', {
+    type: 'string',
+    desc: 'Ignore the next option (useful for lint-staged)'
+  })
 
 cli.command('help', 'Display task description', (input, flags) => {
   const runner = require('..')(flags)

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,14 @@ class Maid {
     }
   }
 
+  listTasks() {
+    return this.maidfile.tasks.map(task => task.name)
+  }
+
+  getFilepath() {
+    return this.maidfile.filepath
+  }
+
   async runTasks(taskNames, inParallel) {
     if (!taskNames || taskNames.length === 0) return
 

--- a/lib/runCLICommand.js
+++ b/lib/runCLICommand.js
@@ -2,13 +2,17 @@ const path = require('path')
 const spawn = require('cross-spawn')
 const MaidError = require('./MaidError')
 
-module.exports = ({ task, type = task.type, resolve, reject }) => {
-  const cmd = spawn(type, ['-c', task.script, ...process.argv.slice(2)], {
+const exec = (cmd, args) =>
+  spawn(cmd, args, {
     stdio: 'inherit',
-    env: Object.assign({}, process.env, {
+    env: {
+      ...process.env,
       PATH: `${path.resolve('node_modules/.bin')}:${process.env.PATH}`
-    })
+    }
   })
+
+module.exports = ({ task, type = task.type, resolve, reject }) => {
+  const cmd = exec(type, ['-c', task.script, ...process.argv.slice(2)])
 
   cmd.on('close', code => {
     if (code === 0) {
@@ -20,3 +24,5 @@ module.exports = ({ task, type = task.type, resolve, reject }) => {
 
   return cmd
 }
+
+module.exports.exec = exec

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -52,7 +52,12 @@ module.exports = (maid, flags) => {
       : 'maid'
 
   const { scripts = {} } = pkg
-  const tasks = maid.listTasks()
+  const tasks = maid
+    .listTasks()
+    .filter(
+      (task, index, tasks) =>
+        !tasks.includes((task.match(/(?:pre|post)(.*)/) || [])[1])
+    )
   const passThroughArgs = getPassThroughArgs(flags)
 
   const baseScripts = Object.keys(scripts)

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -13,9 +13,10 @@ module.exports = (maid, flags) => {
   const { path: pkgPath, data: pkg } = loadFile.loadSync(['package.json'])
   if (!pkgPath) return null
 
-  const maidExec = process.argv[1].endsWith('.js')
-    ? `node ${path.relative(process.cwd(), process.argv[1])}`
-    : 'maid'
+  const maidExec =
+    path.basename(process.argv[0]) === 'node'
+      ? `node ${path.relative(process.cwd(), process.argv[1])}`
+      : 'maid'
 
   const { scripts = {} } = pkg
   const tasks = maid.listTasks()

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -9,6 +9,38 @@ const flattenObj = (a, b) => ({
   ...b
 })
 
+const getPassThroughArgs = flags => {
+  const passThroughArgs = []
+
+  if (flags.quiet) {
+    passThroughArgs.push('--quiet')
+  }
+
+  if (flags.section) {
+    passThroughArgs.push('-s', flags.section)
+  }
+
+  const pathIndex = process.argv.findIndex(arg => arg.match(/-p|--path/)) + 1
+  if (pathIndex) {
+    passThroughArgs.push('-p', process.argv[pathIndex])
+  }
+
+  return passThroughArgs.join(' ')
+}
+
+const checkForTaskConflicts = (maidTasks, customScripts) => {
+  const conflictingTasks = maidTasks.filter(task =>
+    Object.keys(customScripts).includes(task)
+  )
+
+  if (conflictingTasks.length) {
+    throw new MaidError(
+      `Conflicts between maidfile and package.json. Please check these scripts: \n\t
+        ${conflictingTasks.join(', ')}`
+    )
+  }
+}
+
 module.exports = (maid, flags) => {
   const { path: pkgPath, data: pkg } = loadFile.loadSync(['package.json'])
   if (!pkgPath) return null
@@ -20,27 +52,14 @@ module.exports = (maid, flags) => {
 
   const { scripts = {} } = pkg
   const tasks = maid.listTasks()
-
-  const passThroughArgs = process.argv
-    .slice(2)
-    .filter(arg => !['update-scripts', '--git-add'].includes(arg))
-    .join(' ')
+  const passThroughArgs = getPassThroughArgs(flags)
 
   const baseScripts = Object.keys(scripts)
     .filter(task => !scripts[task].startsWith(maidExec))
     .map(task => ({ [task]: scripts[task] }))
     .reduce(flattenObj, {})
 
-  const conflictingTasks = tasks.filter(task =>
-    Object.keys(baseScripts).includes(task)
-  )
-
-  if (conflictingTasks.length) {
-    throw new MaidError(
-      `Conflicts between maidfile and package.json. Please check these scripts: \n\t
-        ${conflictingTasks.join(', ')}`
-    )
-  }
+  checkForTaskConflicts(tasks, baseScripts)
 
   const finalScripts = tasks
     .map(task => ({

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -68,7 +68,6 @@ module.exports = (maid, flags) => {
     }))
     .reduce(flattenObj, baseScripts)
 
-  console.log(flags)
   if (flags.write) {
     fs.writeFileSync(
       pkgPath,

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -3,6 +3,7 @@ const MaidError = require('./MaidError')
 const fs = require('fs')
 const path = require('path')
 const { exec } = require('./runCLICommand')
+const logger = require('./logger')
 
 const flattenObj = (a, b) => ({
   ...a,
@@ -67,10 +68,16 @@ module.exports = (maid, flags) => {
     }))
     .reduce(flattenObj, baseScripts)
 
-  fs.writeFileSync(
-    pkgPath,
-    JSON.stringify({ ...pkg, ...{ scripts: finalScripts } }, null, 2)
-  )
+  console.log(flags)
+  if (flags.write) {
+    fs.writeFileSync(
+      pkgPath,
+      JSON.stringify({ ...pkg, ...{ scripts: finalScripts } }, null, 2)
+    )
+  } else {
+    logger.log('\n', finalScripts)
+  }
+
   if (flags.gitAdd) {
     exec('git', ['add', pkgPath])
   }

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -2,13 +2,14 @@ const loadFile = require('./loadFile')
 const MaidError = require('./MaidError')
 const fs = require('fs')
 const path = require('path')
+const { exec } = require('./runCLICommand')
 
 const flattenObj = (a, b) => ({
   ...a,
   ...b
 })
 
-module.exports = maid => {
+module.exports = (maid, flags) => {
   const { path: pkgPath, data: pkg } = loadFile.loadSync(['package.json'])
   if (!pkgPath) return null
 
@@ -21,7 +22,7 @@ module.exports = maid => {
 
   const passThroughArgs = process.argv
     .slice(2)
-    .filter(arg => arg !== '--update-scripts')
+    .filter(arg => !['update-scripts', '--git-add'].includes(arg))
     .join(' ')
 
   const baseScripts = Object.keys(scripts)
@@ -50,4 +51,7 @@ module.exports = maid => {
     pkgPath,
     JSON.stringify({ ...pkg, ...{ scripts: finalScripts } }, null, 2)
   )
+  if (flags.gitAdd) {
+    exec('git', ['add', pkgPath])
+  }
 }

--- a/lib/updateScripts.js
+++ b/lib/updateScripts.js
@@ -1,0 +1,53 @@
+const loadFile = require('./loadFile')
+const MaidError = require('./MaidError')
+const fs = require('fs')
+const path = require('path')
+
+const flattenObj = (a, b) => ({
+  ...a,
+  ...b
+})
+
+module.exports = maid => {
+  const { path: pkgPath, data: pkg } = loadFile.loadSync(['package.json'])
+  if (!pkgPath) return null
+
+  const maidExec = process.argv[1].endsWith('.js')
+    ? `node ${path.relative(process.cwd(), process.argv[1])}`
+    : 'maid'
+
+  const { scripts = {} } = pkg
+  const tasks = maid.listTasks()
+
+  const passThroughArgs = process.argv
+    .slice(2)
+    .filter(arg => arg !== '--update-scripts')
+    .join(' ')
+
+  const baseScripts = Object.keys(scripts)
+    .filter(task => !scripts[task].startsWith(maidExec))
+    .map(task => ({ [task]: scripts[task] }))
+    .reduce(flattenObj, {})
+
+  const conflictingTasks = tasks.filter(task =>
+    Object.keys(baseScripts).includes(task)
+  )
+
+  if (conflictingTasks.length) {
+    throw new MaidError(
+      `Conflicts between maidfile and package.json. Please check these scripts: \n\t
+        ${conflictingTasks.join(', ')}`
+    )
+  }
+
+  const finalScripts = tasks
+    .map(task => ({
+      [task]: `${maidExec} ${passThroughArgs} ${task}`.replace(/\s+/g, ' ')
+    }))
+    .reduce(flattenObj, baseScripts)
+
+  fs.writeFileSync(
+    pkgPath,
+    JSON.stringify({ ...pkg, ...{ scripts: finalScripts } }, null, 2)
+  )
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node bin/cli.js -p README.md lint",
-    "test": "node bin/cli.js -p README.md test",
-    "toc": "node bin/cli.js -p README.md toc"
+    "lint": "maid -p /Users/justinbennett/Git/oss/maid/README.md lint",
+    "test": "maid -p /Users/justinbennett/Git/oss/maid/README.md test",
+    "toc": "maid -p /Users/justinbennett/Git/oss/maid/README.md toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node bin/cli -p README.md lint",
-    "test": "node bin/cli -p README.md test",
-    "toc": "node bin/cli -p README.md toc"
+    "lint": "node bin/cli lint",
+    "test": "node bin/cli test",
+    "toc": "node bin/cli toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",
@@ -65,7 +65,7 @@
     ],
     "README.md": [
       "node bin/cli toc",
-      "node bin/cli update-scripts --git-add -p",
+      "node bin/cli update-scripts --git-add --noop",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
   },
   "main": "lib/index.js",
   "bin": "bin/cli.js",
-  "files": [
-    "bin",
-    "lib"
-  ],
+  "files": ["bin", "lib"],
   "scripts": {
     "lint": "node bin/cli lint",
     "test": "node bin/cli test",
@@ -43,11 +40,7 @@
     "prettier": "^1.13.3"
   },
   "eslintConfig": {
-    "extends": [
-      "xo",
-      "rem",
-      "plugin:prettier/recommended"
-    ],
+    "extends": ["xo", "rem", "plugin:prettier/recommended"],
     "rules": {
       "unicorn/filename-case": "off",
       "no-await-in-loop": "off"
@@ -59,16 +52,11 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "node bin/cli lint --fix",
-      "git add"
-    ],
-    "package.json": [
-      "node bin/cli update-scripts --no-write --noop"
-    ],
+    "*.js": ["node bin/cli lint --fix", "git add"],
+    "package.json": ["node bin/cli update-scripts --no-write"],
     "README.md": [
       "node bin/cli toc",
-      "node bin/cli update-scripts --git-add --noop",
+      "node bin/cli update-scripts --git-add",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "test": "node bin/cli lint && node bin/cli test"
+    "lint": "node bin/cli.js lint",
+    "test": "node bin/cli.js test",
+    "toc": "node bin/cli.js toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node bin/cli -p /Users/justinbennett/Git/oss/maid/README.md lint",
-    "test": "node bin/cli -p /Users/justinbennett/Git/oss/maid/README.md test",
-    "toc": "node bin/cli -p /Users/justinbennett/Git/oss/maid/README.md toc"
+    "lint": "node bin/cli -p README.md lint",
+    "test": "node bin/cli -p README.md test",
+    "toc": "node bin/cli -p README.md toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "lint": "maid -p /Users/justinbennett/Git/oss/maid/README.md lint",
-    "test": "maid -p /Users/justinbennett/Git/oss/maid/README.md test",
-    "toc": "maid -p /Users/justinbennett/Git/oss/maid/README.md toc"
+    "lint": "node bin/cli -p README.md lint",
+    "test": "node bin/cli -p README.md test",
+    "toc": "node bin/cli -p README.md toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
       "node bin/cli lint --fix",
       "git add"
     ],
+    "package.json": [
+      "node bin/cli update-scripts --no-write --noop"
+    ],
     "README.md": [
       "node bin/cli toc",
       "node bin/cli update-scripts --git-add --noop",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node bin/cli.js lint",
-    "test": "node bin/cli.js test",
-    "toc": "node bin/cli.js toc"
+    "lint": "node bin/cli.js -p README.md lint",
+    "test": "node bin/cli.js -p README.md test",
+    "toc": "node bin/cli.js -p README.md toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",
@@ -65,6 +65,7 @@
     ],
     "README.md": [
       "node bin/cli toc",
+      "node bin/cli update-scripts --git-add -p",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "lib"
   ],
   "scripts": {
-    "lint": "node bin/cli -p README.md lint",
-    "test": "node bin/cli -p README.md test",
-    "toc": "node bin/cli -p README.md toc"
+    "lint": "node bin/cli -p /Users/justinbennett/Git/oss/maid/README.md lint",
+    "test": "node bin/cli -p /Users/justinbennett/Git/oss/maid/README.md test",
+    "toc": "node bin/cli -p /Users/justinbennett/Git/oss/maid/README.md toc"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Fixes #24 

Adds the ability to write all maid tasks out to the package.json for easier consumption of tasks. 

- [x] add cli command
- [x] implement script writer
- [x] document command
- [x] add lint-staged example
- [x] dogfood setup
- [x] account for pre/post scripts
- [ ] tests
