### PR TITLE
switch all occurances of `node bin/cli` to yarn maid

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lib"
   ],
   "scripts": {
-    "test": "node bin/cli lint && node bin/cli test"
+    "maid": "node bin/cli",
+    "test": "yarn maid lint && yarn maid test"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",
@@ -58,11 +59,11 @@
   },
   "lint-staged": {
     "*.js": [
-      "node bin/cli lint --fix",
+      "yarn maid lint --fix",
       "git add"
     ],
     "README.md": [
-      "node bin/cli toc",
+      "yarn maid toc",
       "git add"
     ]
   }


### PR DESCRIPTION
This makes the things a bit easier for future. Also "single point of truth".