### PR TITLE
Introduce support for running multiple tasks in series

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 const cli = require('cac')()
 const chalk = require('chalk')
+const pMapSeries = require('p-map-series')
 
-cli.command('*', 'Run a task in current working directory', (input, flags) => {
+cli.command('*', 'Run a tasks in current working directory', (input, flags) => {
   const taskName = input[0]
   if (!taskName) {
     return cli.showHelp()
   }
   const runner = require('..')(flags)
-  return runner.runFile(taskName)
+  return pMapSeries(input, name => runner.runFile(name))
 })
 
 cli.command('help', 'Display task description', (input, flags) => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "node bin/cli lint && node bin/cli test"
+    "test": "node bin/cli lint test"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",
@@ -25,6 +25,7 @@
     "joycon": "^1.0.4",
     "markdown-it": "^8.4.1",
     "micromatch": "^3.1.10",
+    "p-map-series": "^1.0.0",
     "require-from-string": "^2.0.2",
     "rexrex": "^1.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3031,9 +3031,19 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-map-series@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-map-series/-/p-map-series-1.0.0.tgz#bf98fe575705658a9e1351befb85ae4c1f07bdca"
+  dependencies:
+    p-reduce "^1.0.0"
+
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+p-reduce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Because why not? It's easy addition.

Example (seen even in the maid's npm scripts)

```bash
maid lint test build

# equivalent of
maid lint && maid test && maid build
```
