### PR TITLE
better gitignore - logs and cov dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+*.log
+.nyc_output
+coverage


### PR DESCRIPTION
Just because some times tasks may fail so `yarn-error.log` will appear. In addition it adds ignores for NYC/istanbul coverage dirs.