### PR TITLE
Add Zsh completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
       - [Asynchronous task](#asynchronous-task)
     - [py/python](#pypython)
   - [Use a custom maidfile](#use-a-custom-maidfile)
+  - [ZSH completion](#zsh-completion)
 - [Development](#development)
   - [lint](#lint)
   - [test](#test)
@@ -265,6 +266,14 @@ Let me explain..
 Unlike a `maidfile.md` which uses all `h2` headers as tasks, in `README.md` only `h3` headers under the specified `h2` header will be used as tasks. You can add a `<!-- maid-tasks -->` comment right below the desired `h2` header.
 
 Alternatively, if you're not using `maidfile.md`, you can also use `--section h2_header` and `--path foo.md` flags to customize it.
+
+### ZSH completion
+
+Add `FPATH` like following to `.zshrc`:
+
+```
+export FPATH=$(npm root -g)/maid/completion/zsh:$FPATH
+```
 
 ## Development
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,6 +16,11 @@ cli.command('help', 'Display task description', (input, flags) => {
   return runner.getHelp(input)
 })
 
+cli.command('list', 'Display task list', (input, flags) => {
+  const runner = require('..')(flags)
+  return runner.getList()
+})
+
 cli.on('error', err => {
   if (err.name === 'MaidError') {
     require('../lib/logger').error(chalk.red(err.message))

--- a/completion/zsh/_maid
+++ b/completion/zsh/_maid
@@ -1,0 +1,17 @@
+#compdef maid
+
+# list of task list
+function __list() {
+    local -a scripts
+
+    scripts=($(maid list))
+    _describe 'script' scripts
+}
+
+_arguments \
+    '(--quiet)'--quiet \
+    '(-p --path)'{-p,--path}': :_files' \
+    '(-v --version)'{-v,--version} \
+    '(-s --section)'{-s,--section} \
+    '(- *)'{-h,--help} \
+    '*: :__list' \

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,11 @@ class Maid {
         '\n'
     )
   }
+
+  getList() {
+    const tasks = this.maidfile.tasks
+    console.log(tasks.map(task => task.name).join('\n'))
+  }
 }
 
 function checkTypes(task, types) {


### PR DESCRIPTION
for #49 

User add `export FPATH=$(npm root -g)/maid/completion/zsh:$FPATH` to their  owned `.zshrc`, then complete task and options.